### PR TITLE
Add session user validation

### DIFF
--- a/fractalis/session.py
+++ b/fractalis/session.py
@@ -18,8 +18,8 @@ class RedisSession(CallbackDict, SessionMixin):
             initial = {
                 'data_tasks': [],
                 'analytic_tasks': [],
-                'subsets': [],
-                'state_access': {}
+                'state_access': {},
+                'user_id': None
             }
 
         def on_update(self):


### PR DESCRIPTION
Currently, the Fractalis session is linked to a browser window or tab. The session stays alive until the window or tab is closed. This means that when a user logs out of a client application (e.g., Glowing Bear), the Fractalis session is still active, i.e., the user can still access the data that is in the Fractalis cache.

Instead, the data should only accessible during the session if we can trust that it is accessed by the same user that started the session, by storing a unique user id in the session and validation the id of the current user with the one stored in the session.

Issue description: [TMT-1061](https://jira.thehyve.nl/browse/TMT-1061)